### PR TITLE
Fix Troubleshooter Itemview in „Current sessions“

### DIFF
--- a/src/postix/core/models/cashdesk.py
+++ b/src/postix/core/models/cashdesk.py
@@ -139,8 +139,7 @@ class CashdeskSession(models.Model):
 
     def get_item_set(self) -> List[Item]:
         return [Item.objects.get(pk=pk)
-                for pk in TransactionPositionItem.objects
-                    .filter(position__transaction__session=self)
+                for pk in self.item_movements
                     .order_by()
                     .values_list('item', flat=True)
                     .distinct()


### PR DESCRIPTION
Before this commit, you only got the items which was sold by the cash desk shift already. They were ordered by the first transaction, too.

If you use the item_movements and order them, you will get all items from the moment the backoffice gave them to the cash desk. Troubleshooter can furthermore see items which are not yet sold by this session.

Feedback welcome :)