### PR TITLE
Fix #39 -- Change cash movement when changing records

### DIFF
--- a/src/postix/backoffice/forms/record.py
+++ b/src/postix/backoffice/forms/record.py
@@ -72,8 +72,9 @@ class RecordUpdateForm(RecordCreateForm):
 
     def save(self, *args, **kwargs):
         i = super().save(*args, **kwargs)
-        self.instance.cash_movement.cash = (-1 if self.instance.type == "inflow" else 1) * self.instance.amount
-        self.instance.cash_movement.save()
+        if self.instance.cash_movement:
+            self.instance.cash_movement.cash = (-1 if self.instance.type == "inflow" else 1) * self.instance.amount
+            self.instance.cash_movement.save()
         return i
 
 

--- a/src/postix/backoffice/forms/record.py
+++ b/src/postix/backoffice/forms/record.py
@@ -70,6 +70,12 @@ class RecordUpdateForm(RecordCreateForm):
         model = Record
         fields = ('type', 'datetime', 'entity', 'carrier', 'amount', 'backoffice_user')
 
+    def save(self, *args, **kwargs):
+        i = super().save(*args, **kwargs)
+        self.instance.cash_movement.cash = (-1 if self.instance.type == "inflow" else 1) * self.instance.amount
+        self.instance.cash_movement.save()
+        return i
+
 
 class RecordEntityForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
This should be the necessary change to fix #39. This is the first time we change CashMovement objects after the fact, which is why I'm a bit cautious about, but as long as we allow records to change it's probably fine.